### PR TITLE
Prevent running 5 jobs in `test` stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,4 @@
 language: rust
-rust:
-  - 1.33.0  # pinned stable Rust release
-  - stable
-  #- beta
-  #- nightly
-os:
-  - linux
-  - osx
 branches:
   only:
     - master
@@ -18,17 +10,25 @@ stages:
   - test
   - doc-bench-deploy
 
+# test stage
+rust:
+  - 1.33.0  # pinned stable Rust release
+  - stable
+  #- beta
+  #- nightly
+os:
+  - linux
+  - osx
+script:
+  - cargo build --release --verbose --all
+  - cargo test --release --verbose --all
+
 jobs:
   include:
     - stage: pr-check-fix
       rust: stable
       os: linux
       script: ./ci/pr-check-fix.sh
-
-    - stage: test
-      script:
-        - cargo build --release --verbose --all
-        - cargo test --release --verbose --all
 
     - stage: doc-bench-deploy
       rust: stable


### PR DESCRIPTION
## Problem
https://travis-ci.com/laysakura/fid-rs/builds/109530167

![image](https://user-images.githubusercontent.com/498788/56701815-dc674e80-673b-11e9-9906-04c631dc6611.png)

Upper 4 jobs take 3 min. It runs default script `cargo test --verbose`.

Below 1 job takes 1 min. It runs my script `cargo test --release --verbose`.