### PR TITLE
Refactoring of select() to remove duplicate code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 
 # used for debugging with VSCode
 src/main.rs
+.vscode/launch.json

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -72,7 +72,7 @@ mod fid {
                         // iter_batched() does not properly time `routine` time when `setup` time is far longer than `routine` time.
                         // Tested function takes too short compared to build(). So loop many times.
                         for _ in 0..times {
-                            assert_eq!(fid.rank(n - 1), 0);
+                            assert_eq!(fid.rank1(n - 1), 0);
                         }
                     },
                     BatchSize::SmallInput,
@@ -97,7 +97,7 @@ mod fid {
                         // iter_batched() does not properly time `routine` time when `setup` time is far longer than `routine` time.
                         // Tested function takes too short compared to build(). So loop many times.
                         for _ in 0..times {
-                            assert_eq!(fid.select(n - 1), Some(n - 2));
+                            assert_eq!(fid.select1(n - 1), Some(n - 2));
                         }
                     },
                     BatchSize::SmallInput,

--- a/src/fid.rs
+++ b/src/fid.rs
@@ -129,8 +129,6 @@ struct Chunks {
 struct Chunk {
     value: u64, // popcount
     blocks: Blocks,
-
-    #[allow(dead_code)]
     length: u16,
 }
 

--- a/src/internal_data_structure/raw_bit_vector.rs
+++ b/src/internal_data_structure/raw_bit_vector.rs
@@ -79,13 +79,9 @@ impl<'s> RawBitVector<'s> {
 
     /// Returns length.
     pub fn len(&self) -> u64 {
-        if self.byte_slice.len() == 1 {
-            self.last_byte_len as u64 - self.first_byte_offset as u64
-        } else {
-            (self.byte_slice.len() as u64) * 8
-                - (self.first_byte_offset as u64)
-                - (8 - self.last_byte_len as u64)
-        }
+        (self.byte_slice.len() as u64) * 8
+            - (self.first_byte_offset as u64)
+            - (8 - self.last_byte_len as u64)
     }
 
     /// Returns popcount of whole this bit vector.
@@ -109,7 +105,7 @@ impl<'s> RawBitVector<'s> {
         };
         popcnt -= left_1s_byte.count_ones() as u64;
 
-        // remove 1s in the left of last_byte_len
+        // remove 1s in the right of last_byte_len
         let last_byte = self.byte_slice.last().unwrap();
         let last_offset = self.last_byte_len - 1;
         let right_1s_byte = match last_offset {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,14 +36,14 @@
 //! assert_eq!(fid[1], true);   // 0[1]001; 1st bit is '1' (true)
 //! assert_eq!(fid[4], true);   // 0100[1]; 4th bit is '1' (true)
 //!
-//! assert_eq!(fid.rank(0), 0);  // [0]1001; Range [0, 0] has no '1'
-//! assert_eq!(fid.rank(3), 1);  // [0100]1; Range [0, 3] has 1 '1'
-//! assert_eq!(fid.rank(4), 2);  // [01001]; Range [0, 4] has 2 '1's
+//! assert_eq!(fid.rank1(0), 0);  // [0]1001; Range [0, 0] has no '1'
+//! assert_eq!(fid.rank1(3), 1);  // [0100]1; Range [0, 3] has 1 '1'
+//! assert_eq!(fid.rank1(4), 2);  // [01001]; Range [0, 4] has 2 '1's
 //!
-//! assert_eq!(fid.select(0), Some(0)); // []01001; Minimum i where range [0, i] has 0 '1's is i=0
-//! assert_eq!(fid.select(1), Some(1)); // 0[1]001; Minimum i where range [0, i] has 1 '1's is i=1
-//! assert_eq!(fid.select(2), Some(4)); // 0100[1]; Minimum i where range [0, i] has 2 '1's is i=4
-//! assert_eq!(fid.select(3), None);    // There is no i where range [0, i] has 3 '1's
+//! assert_eq!(fid.select1(0), Some(0)); // []01001; Minimum i where range [0, i] has 0 '1's is i=0
+//! assert_eq!(fid.select1(1), Some(1)); // 0[1]001; Minimum i where range [0, i] has 1 '1's is i=1
+//! assert_eq!(fid.select1(2), Some(4)); // 0100[1]; Minimum i where range [0, i] has 2 '1's is i=4
+//! assert_eq!(fid.select1(3), None);    // There is no i where range [0, i] has 3 '1's
 //!
 //! // rank0, select0 -----------------------
 //! assert_eq!(fid.rank0(0), 1);  // [0]1001; Range [0, 0] has no '0'

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -91,24 +91,24 @@ fn fuzzing_test() {
 
             eprintln!("rank(): bit vec = \"{}\", i = {}, ", s, i);
             assert_eq!(
-                fid.rank(i as u64),
+                fid.rank1(i as u64),
                 rank_from_bit_string(s, i as u64),
                 "bit vec = \"{}\", i={}, Fid::rank()={}, rank_from_bit_string={}",
                 s,
                 i,
-                fid.rank(i as u64),
+                fid.rank1(i as u64),
                 rank_from_bit_string(s, i as u64)
             );
 
             let num = i as u64;
             eprintln!("select(): bit vec = \"{}\", num = {}, ", s, num);
             assert_eq!(
-                fid.select(num),
+                fid.select1(num),
                 select_from_bit_string(s, num),
                 "bit vec = \"{}\", num={}, Fid::select()={:?}, select_from_bit_string={:?}",
                 s,
                 num,
-                fid.select(num),
+                fid.select1(num),
                 select_from_bit_string(s, num)
             );
 


### PR DESCRIPTION
I'm so glad I found your code and also your LOUDS crate. I will try to use it to write a keyboard with next word prediction and gesture recognition. I am going through the code to understand it. Looks great :) I only have a small suggestion:

The code in the methods select() and select0() were very similar. Also you had to read the documentation to know if rank() returns the number of 0 or 1. I renamed rank() to rank1() and created a new method rank() that takes as additional input a bool to select if 0 or 1 should be counted.

Of course I ran the tests after the changes and they all pass.

Would you also be open for a pull request to select the chunk/block size?